### PR TITLE
Escape URI

### DIFF
--- a/lib/rbattlenet/rbattlenet.rb
+++ b/lib/rbattlenet/rbattlenet.rb
@@ -61,7 +61,7 @@ module RBattlenet
     #Wrapper for HTTParty requests that injects query parameters
     def get(uri, queries = @@queries)
       begin
-        HTTParty.get(uri + queries)
+        HTTParty.get(URI.escape(uri + queries))
       rescue
         RBattlenet::Errors::ConnectionError
       end
@@ -70,10 +70,6 @@ module RBattlenet
     #Sets base uri for requests
     def base_uri(path)
       "https://#{@@region}.api.battle.net/#{path}"
-    end
-
-    def parse_spaces(input)
-      input.gsub(" ", '%20')
     end
 
     #Merges required and optional query parameters

--- a/lib/rbattlenet/wow/challenge.rb
+++ b/lib/rbattlenet/wow/challenge.rb
@@ -2,7 +2,6 @@ module RBattlenet
   module Wow
     class Challenge
       def self.find_realm(realm:)
-        realm =  RBattlenet.parse_spaces(realm)
 
         uri = RBattlenet.
           base_uri("#{GAME}/challenge/#{realm}")

--- a/lib/rbattlenet/wow/character.rb
+++ b/lib/rbattlenet/wow/character.rb
@@ -3,7 +3,6 @@ module RBattlenet
     class Character
       def self.find(name:, realm:, fields: nil)
         fields = RBattlenet.parse_fields(fields)
-        realm =  RBattlenet.parse_spaces(realm)
         queries = RBattlenet.merge_queries(fields)
 
         uri = RBattlenet.

--- a/lib/rbattlenet/wow/guild.rb
+++ b/lib/rbattlenet/wow/guild.rb
@@ -2,9 +2,7 @@ module RBattlenet
   module Wow
     class Guild
       def self.find(name:, realm:, fields: nil)
-        name = RBattlenet.parse_spaces(name)
         fields = RBattlenet.parse_fields(fields)
-        realm =  RBattlenet.parse_spaces(realm)
         queries = RBattlenet.merge_queries(fields)
 
         uri = RBattlenet.


### PR DESCRIPTION
URI must be escaped or the API doesn't work with usernames / realm names using non-ASCII characters
