### PR TITLE
updated httparty to newest version due to json 1.8/2.0 conflicts

### DIFF
--- a/rbattlenet.gemspec
+++ b/rbattlenet.gemspec
@@ -25,5 +25,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'vcr', '~> 2.9.3'
   spec.add_development_dependency "webmock"
 
-  spec.add_runtime_dependency "httparty", "~> 0.13.6"
+  spec.add_runtime_dependency 'httparty', '~> 0.16.1'
 end


### PR DESCRIPTION
newest version of httparty (0.16) utilizes json 2.0.2 which conflicts with json 1.8. Updated Httparty to newest version. Ran rspec tests. Out of 43 Tests, 14 failed. Each failed due to the API no longer having data that met the requirements of the test.