### PR TITLE
Suppress encoding warning

### DIFF
--- a/lib/rbattlenet/rbattlenet.rb
+++ b/lib/rbattlenet/rbattlenet.rb
@@ -35,7 +35,7 @@ module RBattlenet
       hydra = Typhoeus::Hydra.new(max_concurrency: @@concurrency)
       subjects.each do |uris, subject|
         uris.each do |field, uri|
-          request = Typhoeus::Request.new(URI.encode(uri), headers: headers, timeout: @@timeout)
+          request = Typhoeus::Request.new(URI::DEFAULT_PARSER.escape(uri), headers: headers, timeout: @@timeout)
 
           request.on_complete do |response|
             if @@response_type == :raw


### PR DESCRIPTION
I recently started using this Gem and have been receiving a warning that `URI::escape` is obsolete. This change eliminates that warning. I took this idea from [this PR](https://github.com/mongodb/mongo-ruby-driver/pull/1614) on the mongo-ruby-driver.